### PR TITLE
feat(api): loadSession endpoint for session management

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -19,8 +19,11 @@ def loadData(filename: str):
   return session.model_dump(by_alias=True, mode="json")
 
 
-def loadSession(filename: str, new_session: SessionModel):
+def loadSession(filename: str, new_session: dict[str, Any] | SessionModel):
   global session
+  if isinstance(new_session, dict):
+    new_session = SessionModel.model_validate(new_session)
+
   session = SessionModel(filename=filename)
   session.charts = new_session.charts
   session.timestamp = new_session.timestamp
@@ -40,14 +43,6 @@ def appendNextChart():
   chart = get_next_chart(session)
   session.charts.append(chart) if chart else None
   return chart.model_dump(by_alias=True, mode="json") if chart else None
-
-
-def restoreSession(new_state: dict[str, Any] | SessionModel):
-  global session
-  if isinstance(new_state, dict):
-    new_state = SessionModel.model_validate(new_state)
-  session = new_state
-  return session.model_dump(by_alias=True, mode="json")
 
 
 def browseCharts(field_names: list[str]):

--- a/api/app.py
+++ b/api/app.py
@@ -19,6 +19,14 @@ def loadData(filename: str):
   return session.model_dump(by_alias=True, mode="json")
 
 
+def loadSession(filename: str, new_session: SessionModel):
+  global session
+  session = SessionModel(filename=filename)
+  session.charts = new_session.charts
+  session.timestamp = new_session.timestamp
+  return session.model_dump(by_alias=True, mode="json")
+
+
 def appendChart(chart: dict[str, Any] | ChartModel):
   global session
   if isinstance(chart, dict):

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from api.app import appendChart, appendNextChart, browseCharts, loadData
-from api.models import ChartModel
+from api.app import appendChart, appendNextChart, browseCharts, loadData, loadSession
+from api.models import ChartModel, SessionModel
 from fastapi import FastAPI, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
@@ -16,6 +16,14 @@ async def load_data(file: UploadFile):
   with open(f"data/{file.filename}", "wb") as buffer:
     buffer.write(await file.read())
   return loadData(f"data/{file.filename}")
+
+
+@server.post("/api/loadSession")
+async def load_session(file: UploadFile, new_session: SessionModel):
+  Path("data").mkdir(parents=True, exist_ok=True)
+  with open(f"data/{file.filename}", "wb") as buffer:
+    buffer.write(await file.read())
+  return loadSession(f"data/{file.filename}", new_session)
 
 
 class BrowseChartRequest(BaseModel):


### PR DESCRIPTION
This pull request introduces a new `loadSession` endpoint to the API, allowing users to load session data from a specified file. The implementation includes a function that validates and sets the session based on the provided data, enhancing session management capabilities. Additionally, the necessary imports and endpoint definitions have been updated to support this new feature.