### PR TITLE
feat(api): setPreferred API endpoint and fix chart key reference

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -51,9 +51,9 @@ def browseCharts(field_names: list[str]):
   return [chart.model_dump(by_alias=True, mode="json") for chart in browsed_chart]
 
 
-def setPreferred(chart_key: str, preferred: bool):
+def setPreferred(key: str, preferred: bool):
   global session
-  chart = next((chart for chart in session.charts if chart.key == chart_key), None)
+  chart = next((chart for chart in session.charts if chart.key == key), None)
   if chart:
     chart.preferred = preferred
     return chart.model_dump(by_alias=True, mode="json")

--- a/api/app.py
+++ b/api/app.py
@@ -49,3 +49,13 @@ def browseCharts(field_names: list[str]):
   global session
   browsed_chart = browse_charts(session, field_names)
   return [chart.model_dump(by_alias=True, mode="json") for chart in browsed_chart]
+
+
+def setPreferred(chart_key: str, preferred: bool):
+  global session
+  chart = next((chart for chart in session.charts if chart.key == chart_key), None)
+  if chart:
+    chart.preferred = preferred
+    return chart.model_dump(by_alias=True, mode="json")
+  else:
+    return None

--- a/server.py
+++ b/server.py
@@ -51,13 +51,13 @@ async def append_next_chart():
 
 
 class SetPreferredRequest(BaseModel):
-  chart_key: str = Field(default="", alias="chartKey")
+  key: str = Field(default="", alias="key")
   preferred: bool = Field(default=False)
 
 
 @server.patch("/api/setPreferred")
 async def set_preferred(req: SetPreferredRequest):
-  chart = setPreferred(req.chart_key, req.preferred)
+  chart = setPreferred(req.key, req.preferred)
   return HTTPException(status_code=404, detail="Chart not found") if not chart else chart
 
 

--- a/server.py
+++ b/server.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from api.app import appendChart, appendNextChart, browseCharts, loadData, loadSession
+from api.app import appendChart, appendNextChart, browseCharts, loadData, loadSession, setPreferred
 from api.models import ChartModel, SessionModel
 from fastapi import FastAPI, HTTPException, UploadFile, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 server = FastAPI()
 
@@ -48,6 +48,17 @@ async def append_chart(req: AppendChartRequest):
 async def append_next_chart():
   chart = appendNextChart()
   return HTTPException(status_code=404, detail="No more charts") if not chart else chart
+
+
+class SetPreferredRequest(BaseModel):
+  chart_key: str = Field(default="", alias="chartKey")
+  preferred: bool = Field(default=False)
+
+
+@server.patch("/api/setPreferred")
+async def set_preferred(req: SetPreferredRequest):
+  chart = setPreferred(req.chart_key, req.preferred)
+  return HTTPException(status_code=404, detail="Chart not found") if not chart else chart
 
 
 @server.get("/api", status_code=status.HTTP_200_OK)


### PR DESCRIPTION
This pull request introduces a new API endpoint `/api/setPreferred` that allows users to set a chart as preferred based on its key. Additionally, it corrects the reference from `chart_key` to `key` in the relevant areas of the code. The changes enhance the API's functionality and improve code clarity.