### PR TITLE
refactor(src,api): refactor writeFile endpoint and related functionality

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -13,14 +13,6 @@ def getSession():
   return session
 
 
-def loadData(filename: str):
-  global session
-  session = SessionModel(filename=filename)
-  chart = get_next_chart(session)
-  session.charts.append(chart) if chart else None
-  return session.model_dump(by_alias=True, mode="json")
-
-
 def loadSession(filename: str, new_session: dict[str, Any] | SessionModel):
   global session
   if isinstance(new_session, dict):
@@ -29,6 +21,8 @@ def loadSession(filename: str, new_session: dict[str, Any] | SessionModel):
   session = SessionModel(filename=filename)
   session.charts = new_session.charts
   session.timestamp = new_session.timestamp
+  chart = get_next_chart(session)
+  session.charts.append(chart) if chart else None
   return session.model_dump(by_alias=True, mode="json")
 
 

--- a/api/models/session_model.py
+++ b/api/models/session_model.py
@@ -37,7 +37,7 @@ class SessionModel(BaseModel):
     clear_field_name_cache()
     if self.df is None:
       extension = get_file_extension(self.filename)
-      self.df = getattr(pd, f"read_{extension}")(Path("./", self.filename))
+      self.df = getattr(pd, f"read_{extension}")(Path("data", self.filename))
       self.df = self.df if len(self.df) <= 5000 else self.df.sample(5000)
     self.fields = [FieldModel.from_dataframe(self.df, name) for name in self.df.columns]
     self.df.rename(columns=get_clingo_field_name, inplace=True)

--- a/src/hooks/useLoadData.ts
+++ b/src/hooks/useLoadData.ts
@@ -1,15 +1,21 @@
 import { useDataStore, useInteractionStore, useSessionsStore } from "@stores";
 
 function useLoadData() {
-  const loadingData = useDataStore((state) => state.loading);
-  const loadData = useDataStore((state) => state.loadData);
+  const loadingData = useDataStore((state) => state.writingFile);
+  const writeFile = useDataStore((state) => state.writeFile);
   const loadingSession = useSessionsStore((state) => state.loadingSession);
   const loadSession = useSessionsStore((state) => state.loadSession);
   const setExpanded = useInteractionStore((state) => state.setDrawerExpanded);
-
+  const resetSession = useSessionsStore((state) => state.resetSession);
+  const sessionFileName = useSessionsStore((state) => state.filename);
   const initializeSession = async (file: File | string) => {
-    await loadData(file);
-    await loadSession();
+    const filename = await writeFile(file);
+
+    if (filename !== sessionFileName) {
+      resetSession();
+    }
+
+    await loadSession(filename);
     setExpanded(false);
   };
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 export default function useSettings() {
   const { apiKey, setApiKey } = useSettingsStore();
-
   const { colorMode, toggleColorMode } = useColorMode();
   const [python, setPython] = useState<"pyodide" | "server">(() => router.getPythonType());
   const toast = useToast();

--- a/src/router/api/index.ts
+++ b/src/router/api/index.ts
@@ -1,13 +1,15 @@
 import appendChart from "./appendChart";
 import appendNextChart from "./appendNextChart";
 import browseCharts from "./browseCharts";
-import loadData from "./loadData";
+import loadSession from "./loadSession";
 import setPreferred from "./setPreferred";
+import writeFile from "./writeFile";
 
 export default {
   appendChart,
   appendNextChart,
   browseCharts,
-  loadData,
+  loadSession,
+  writeFile,
   setPreferred,
 } as const;

--- a/src/router/api/loadSession.ts
+++ b/src/router/api/loadSession.ts
@@ -1,0 +1,24 @@
+import { type TSession } from "@shared/models";
+import { getPyodide } from "@workers";
+import type { TEndpoint } from "./TEndpoint";
+
+type FLoadSession = ({ session }: { session: TSession }) => Promise<TSession>;
+
+async function loadSessionPyodide({ session }: { session: TSession }) {
+  const pyodide = await getPyodide();
+  return pyodide.callPythonFunction("loadSession", { session });
+}
+
+async function loadSessionFetch({ session }: { session: TSession }) {
+  const response = await fetch("/api/loadSession", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(session),
+  });
+  return (await response.json()) as TSession;
+}
+
+export default {
+  pyodide: loadSessionPyodide,
+  server: loadSessionFetch,
+} as TEndpoint<FLoadSession>;

--- a/src/router/api/writeFile.ts
+++ b/src/router/api/writeFile.ts
@@ -1,16 +1,15 @@
-import { type TSession } from "@shared/models";
 import { getPyodide } from "@workers";
 import type { TEndpoint } from "./TEndpoint";
 
-type FLoadData = ({
+type FWriteFile = ({
   filename,
   fileBuffer,
 }: {
   filename: string;
   fileBuffer: Uint8Array;
-}) => Promise<TSession>;
+}) => Promise<void>;
 
-async function loadDataPyodide({
+async function writeFilePyodide({
   filename,
   fileBuffer,
 }: {
@@ -19,11 +18,9 @@ async function loadDataPyodide({
 }) {
   const pyodide = await getPyodide();
   await pyodide.writeFile(filename, fileBuffer);
-  const data = await pyodide.callPythonFunction("loadData", { filename });
-  return data;
 }
 
-async function loadDataFetch({
+async function writeFileFetch({
   filename,
   fileBuffer,
 }: {
@@ -33,15 +30,13 @@ async function loadDataFetch({
   const blob = new Blob([fileBuffer]);
   const formData = new FormData();
   formData.append("file", blob, filename);
-  const response = await fetch("/api/loadData", {
+  await fetch("/api/writeFile", {
     method: "POST",
     body: formData,
   });
-  const data = (await response.json()) as TSession;
-  return data;
 }
 
 export default {
-  pyodide: loadDataPyodide,
-  server: loadDataFetch,
-} as TEndpoint<FLoadData>;
+  pyodide: writeFilePyodide,
+  server: writeFileFetch,
+} as TEndpoint<FWriteFile>;

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -96,6 +96,22 @@ class Router {
       return null;
     }
   }
+
+  public async lazyCall<E extends TEndpointKey>(
+    endpoint: E,
+    args?: TEndpointArgs<E, typeof this.python>,
+  ) {
+    return new Promise((resolve) => {
+      const check = () => {
+        if (!this.getLoadingStatus().loading) {
+          this.off("loadingStatusChange", check);
+          resolve(this.call(endpoint, args));
+        }
+      };
+      this.on("loadingStatusChange", check);
+      check();
+    });
+  }
 }
 
 export default new Router();

--- a/src/workers/manifest.ts
+++ b/src/workers/manifest.ts
@@ -2,10 +2,10 @@ import type { TChart, TSession } from "@shared/models";
 import type { WorkerManifest } from "./types";
 
 export interface PythonManifest extends WorkerManifest {
-  loadData: {
+  loadSession: {
     returns: TSession;
     args: {
-      filename: string;
+      session: TSession;
     };
   };
 


### PR DESCRIPTION
This pull request refactors the existing `loadData` functionality by splitting it into a new `writeFile` endpoint. The changes include updating the API to handle file writing separately, modifying the frontend to utilize the new endpoint, and ensuring that session loading is correctly managed. This enhances the clarity and maintainability of the codebase while improving the overall file handling process. Additionally, the session management logic has been adjusted to accommodate these changes.