### PR TITLE
Minimize interaction in chart browsing

### DIFF
--- a/api/services/browse_charts.py
+++ b/api/services/browse_charts.py
@@ -1,5 +1,4 @@
-from api.models.chart_model import ChartModel
-from api.models.session_model import SessionModel
+from api.models import ChartModel, SessionModel
 
 from .get_chart import get_chart
 
@@ -8,16 +7,13 @@ def browse_charts(state: SessionModel, field_names: list[str]) -> list[ChartMode
   if not (field_names and (0 < len(field_names) <= 3)):
     raise ValueError("Invalid number of fields to browse")
 
-  # Input fields
-  all_fields = state.visualizable_fields
+  browsed_fields = [
+    field_tuple
+    for field_tuple in state.available_fields
+    if len(field_tuple) <= (len(field_names) + 1)
+    if all(field_name in [f.name for f in field_tuple] for field_name in field_names)
+  ]
 
-  input_fields = tuple(field for field in state.visualizable_fields if field.name in field_names)
-  # Add one more fields
-  additional_fields = [field for field in all_fields if field not in input_fields]
-
-  browse_fields = [
-    input_fields,
-    *[(*input_fields, field) for field in additional_fields if len(input_fields) < 3],
-  ][:10]
-  charts = [get_chart(state.df, fields) for fields in browse_fields]
+  browsed_fields = sorted(browsed_fields, key=lambda field_tuple: len(field_tuple))
+  charts = [get_chart(state.df, fields) for fields in browsed_fields]
   return [chart for chart in charts if chart]

--- a/api/services/get_chart.py
+++ b/api/services/get_chart.py
@@ -6,16 +6,17 @@ from api.models import ChartModel, FieldModel
 from .get_facts import get_facts_from_fields
 from .get_specs import get_specs_from_facts
 
-chart_cache = {}
+chart_cache: dict[tuple[FieldModel, ...], ChartModel] = {}
 
 
 def get_chart(df: pd.DataFrame, fields: tuple[FieldModel, ...]) -> ChartModel | None:
   if fields in chart_cache:
-    return chart_cache[fields]
+    cached_chart = chart_cache[fields]
+    return ChartModel(fields=fields, specs=cached_chart.specs) if cached_chart else None
 
   facts = get_facts_from_fields(df, fields)
   specs = get_specs_from_facts(df, facts)
   chart = ChartModel(fields=fields, specs=specs) if specs else None
-  chart_cache[fields] = chart
-
+  if chart:
+    chart_cache[fields] = chart
   return chart

--- a/src/components/Controller.tsx
+++ b/src/components/Controller.tsx
@@ -1,12 +1,6 @@
 import { Button, ButtonGroup, type ButtonGroupProps, Icon, Text, VStack } from "@chakra-ui/react";
 import { useController } from "@hooks";
-import {
-  ArrowLeft01Icon,
-  ArrowRight01Icon,
-  Exchange01Icon,
-  HeartAddIcon,
-  HeartCheckIcon,
-} from "hugeicons-react";
+import { ArrowLeft01Icon, ArrowRight01Icon, HeartAddIcon, HeartCheckIcon } from "hugeicons-react";
 
 function Controller(props: ButtonGroupProps) {
   const {
@@ -15,7 +9,7 @@ function Controller(props: ButtonGroupProps) {
     currentChartPreferred,
     handleNextChart,
     handlePrevChart,
-    handleRenewChart,
+    // handleRenewChart,
     handlePreferChart,
   } = useController();
 
@@ -47,7 +41,7 @@ function Controller(props: ButtonGroupProps) {
           <Text fontSize="sm">Next</Text>
         </VStack>
       </Button>
-      <Button
+      {/* <Button
         py={8}
         size="lg"
         w="full"
@@ -59,7 +53,7 @@ function Controller(props: ButtonGroupProps) {
           <Icon as={Exchange01Icon} boxSize={6} />
           <Text fontSize="sm">Redesign</Text>
         </VStack>
-      </Button>
+      </Button> */}
       <Button
         py={8}
         size="lg"

--- a/src/hooks/useBrowser.ts
+++ b/src/hooks/useBrowser.ts
@@ -21,7 +21,7 @@ export default function useBrowser() {
   const appendChart = useSessionsStore((state) => state.appendChart);
 
   const { data: browsedCharts = [], isLoading: loading } = useQuery({
-    queryKey: ["browseCharts", filename, ...selectedFields],
+    queryKey: ["browseCharts", filename, ...selectedFields.sort()],
     queryFn: async () => {
       if (selectedFields.length === 0 || !data) return [];
       return (await router.call("browseCharts", { fieldNames: selectedFields })) ?? [];

--- a/src/hooks/useChartContainer.ts
+++ b/src/hooks/useChartContainer.ts
@@ -16,6 +16,7 @@ export default function useChartContainer() {
   const currentChartIndex = useSessionsStore((state) => state.currentChartIndex);
   const appendNextChart = useSessionsStore((state) => state.appendNextChart);
   const setCurrentChartIndex = useSessionsStore((state) => state.setCurrentChartIndex);
+  const setCurrentChartPreferred = useSessionsStore((state) => state.setCurrentChartPreferred);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -58,10 +59,18 @@ export default function useChartContainer() {
         event.preventDefault();
         setCurrentChartIndex(currentChartIndex + 1);
       }
+      if (["ArrowUp", "ArrowDown"].includes(event.key)) {
+        event.preventDefault();
+        const currentChartPreferred = charts[currentChartIndex].preferred;
+        setCurrentChartPreferred(!currentChartPreferred);
+        if (!currentChartPreferred) {
+          setCurrentChartIndex(currentChartIndex + 1);
+        }
+      }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [currentChartIndex, setCurrentChartIndex]);
+  }, [currentChartIndex, setCurrentChartIndex, charts, setCurrentChartPreferred]);
 
   return {
     charts,

--- a/src/hooks/useController.ts
+++ b/src/hooks/useController.ts
@@ -8,15 +8,20 @@ export default function useController() {
   const setCurrentChartPreferred = useSessionsStore((state) => state.setCurrentChartPreferred);
   const renewCurrentChart = useSessionsStore((state) => state.renewCurrentChart);
   const currentChartIndex = useSessionsStore((state) => state.currentChartIndex);
+  const currentChartPreferred = currentChartIndex !== -1 && charts[currentChartIndex].preferred;
 
   const chartDisplaying = currentChartIndex !== -1;
-  const currentChartPreferred = currentChartIndex !== -1 && charts[currentChartIndex].preferred;
   const sessionInitialized = fields.length > 0;
 
   const handleRenewChart = renewCurrentChart;
   const handleNextChart = () => setCurrentChartIndex(currentChartIndex + 1);
   const handlePrevChart = () => setCurrentChartIndex(currentChartIndex - 1);
-  const handlePreferChart = () => setCurrentChartPreferred(!currentChartPreferred);
+  const handlePreferChart = () => {
+    setCurrentChartPreferred(!currentChartPreferred);
+    if (!currentChartPreferred) {
+      setCurrentChartIndex(currentChartIndex + 1);
+    }
+  };
 
   return {
     sessionInitialized,


### PR DESCRIPTION
This pull request addresses several interaction-related improvements in the chart browsing experience. It removes the redesign button, allows users to navigate to the next chart upon clicking likes, and eliminates order consideration when browsing charts. Additionally, the ArrowUp key is now mapped to the likes functionality, enhancing user interaction efficiency.

Fixes #64